### PR TITLE
Update CONFIG_FILE path based on BREW_PREFIX

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -3,8 +3,15 @@
 # Whale Helper 프로세스 CPU 과점유 자동 종료 스크립트
 # ============================================================
 
+# Intel: /usr/local, Apple Silicon: /opt/homebrew
+if [[ -d "/opt/homebrew" ]]; then
+    BREW_PREFIX="/opt/homebrew"
+else
+    BREW_PREFIX="/usr/local"
+fi
+
 # 설정 파일 로드
-CONFIG_FILE="$(brew --prefix)/etc/whale-reaper/config"
+CONFIG_FILE="${BREW_PREFIX}/etc/whale-reaper/config"
 [[ -f "$CONFIG_FILE" ]] && source "$CONFIG_FILE"
 
 readonly CPU_THRESHOLD="${WHALE_CPU_THRESHOLD:-20}"


### PR DESCRIPTION
brew --prefix 부분을 하드코딩된 절대 경로로 교체 합니다.

brew 명령어가 PATH에 없어서 발생하는 문제입니다. 터미널에서 직접 실행할 때는 정상이지만, 백그라운드 서비스 환경에서는 /usr/local/bin이 PATH에 포함되지 않습니다.